### PR TITLE
Tossing balls lag back to Crystal levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# BGB
+
+bgb
+
 # compiled objects
 *.o
 

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -239,10 +239,12 @@ PokeBallEffect:
 	ld [wWildMon], a
 	ld a, [wBattleType]
 	cp BATTLETYPE_CONTEST	; Fixes the Park Ball corrupting graphics when used outside of a Contest
-	call nz, ReturnToBattle_UseBall
+	jp z, .skip_return_to_battle
 	cp BATTLETYPE_SAFARI
-	call nz, ReturnToBattle_UseBall
+	jp z, .skip_return_to_battle
+	call ReturnToBattle_UseBall
 
+.skip_return_to_battle
 	ld hl, wOptions
 	res NO_TEXT_SCROLL, [hl]
 	ld hl, ItemUsedText


### PR DESCRIPTION
Cheeky self serving `.gitignore` addition :)

Refactored `wBattleType` check to not double up on the catching routine, reducing lag back to what it is in base Crystal